### PR TITLE
Markdown: Convert Code Block newlines into <br> tags.

### DIFF
--- a/src/blocky-formats.js
+++ b/src/blocky-formats.js
@@ -77,8 +77,8 @@ const go = () => {
 							{
 								label: 'Export to Trac',
 								variant: 'primary',
-								onClick: () => {
-									const trac = window.saveToTrac();
+								onClick: async () => {
+									const trac = await window.saveToTrac();
 
 									navigator.clipboard.writeText(trac);
 								}

--- a/src/markdown.js
+++ b/src/markdown.js
@@ -104,7 +104,7 @@ const blockToMarkdown = (state, block) => {
             return content.split('\n').map(l => `> ${l}`).join('\n') + '\n\n';
 
         case 'core/code':
-            const code = htmlToMarkdown(block.attributes.content);
+            const code = htmlToMarkdown(block.attributes.content).replace(/\n/g, '<br>\n' );
             const languageSpec = block.attributes.language || '';
             return `\`\`\`${languageSpec}\n${code}\n\`\`\`\n\n`;
 


### PR DESCRIPTION
**Do not merge**.

## Status

I can't reproduce the problem, and this solution adds plaintext `<br>`s into the code block, so I think it's wrong.

## Summary

Fixes #1.

When converting code blocks back into Markdown the newlines were not being preserved. The original conversion changes `<br>` tags into newlines, and this patch performs the reverse operation.